### PR TITLE
fix typo on github link

### DIFF
--- a/site-reliability.html
+++ b/site-reliability.html
@@ -117,7 +117,7 @@
                                 </tr>
                                 <tr>
                                     <th scope="row"><a
-                                            href="https://gihub.com/dastergon/awesome-chaos-engineering">awesome-chaos-engineering</a>
+                                            href="https://github.com/dastergon/awesome-chaos-engineering">awesome-chaos-engineering</a>
                                     </th>
                                     <td>A curated list of Chaos Engineering resources.</td>
                                 </tr>


### PR DESCRIPTION
fixed a typo on the link to your awesome-chaos-engineering repo (=